### PR TITLE
Fix for incompatibility with recent versions of "requests" library

### DIFF
--- a/musdk/client.py
+++ b/musdk/client.py
@@ -1,5 +1,5 @@
 import requests
-import simplejson
+import simplejson as json
 
 
 class Client:
@@ -36,7 +36,7 @@ class Client:
 
     def update_traffic(self, data):
         uri = self._gen_node_traffic_url()
-        r = requests.post(uri, json=data, headers=self._gen_headers())
+        r = requests.post(uri, data=json.dumps(data), headers=self._gen_headers())
         if r.status_code != 200:
             return False
         return True


### PR DESCRIPTION
Related error message: `TypeError: request () got an unexpected keyword argument 'json'`
This could be triggered when client.update_traffic() is called.